### PR TITLE
fix: trim trailing spaces on line breaks

### DIFF
--- a/jqfmt_test.go
+++ b/jqfmt_test.go
@@ -278,6 +278,62 @@ func TestMulti(t *testing.T) {
 	}
 }
 
+func TestTrailingWhitespace(t *testing.T) {
+	cfg = JqFmtCfg{
+		Arr: true,
+		Obj: true,
+		Ops: []string{
+			"pipe",
+			"comma",
+			"add",
+			"sub",
+			"mul",
+			"div",
+			"mod",
+			"eq",
+			"ne",
+			"gt",
+			"lt",
+			"ge",
+			"le",
+			"and",
+			"or",
+			"alt",
+			"assign",
+			"modify",
+			"updateAdd",
+			"updateSub",
+			"updateMul",
+			"updateDiv",
+			"updateMod",
+			"updateAlt",
+		},
+	}
+
+	inBytes, err := ioutil.ReadFile("testdata/trailing-space-in.jq")
+	if err != nil {
+		t.Fatalf("failed to open input file: %s", err)
+	}
+	in := string(inBytes)
+
+	wantBytes, err := ioutil.ReadFile("testdata/trailing-space-out.jq")
+	if err != nil {
+		t.Fatalf("failed to open want file: %s", err)
+	}
+	want := string(wantBytes)
+
+	out, err := DoThing(in, cfg)
+	if err != nil {
+		t.Fatalf("could not do thing: %s", err)
+	}
+
+	if !reflect.DeepEqual(want, out) {
+		t.Logf("want: %s", want)
+		t.Logf("have: %s", out)
+		t.Errorf("testdata/trailing-space-in.jq does not match testdata/trailing-space-out.jq")
+	}
+}
+
 /*
 func TestFunction(t *testing.T) {
 	cases := []struct {

--- a/lib.go
+++ b/lib.go
@@ -103,6 +103,7 @@ func prtIdt(s *strings.Builder) {
 
 func brk(s *strings.Builder) {
 
+	trimTrailingSpace(s)
 	s.WriteByte('\n')
 	// idtStr := ""
 	// for i := 0; i < idt; i++ {
@@ -110,6 +111,15 @@ func brk(s *strings.Builder) {
 	// }
 	// s.WriteString(idtStr)
 	line += 1
+}
+
+func trimTrailingSpace(s *strings.Builder) {
+	str := s.String()
+	trimmed := strings.TrimRight(str, " \t")
+	if len(trimmed) != len(str) {
+		s.Reset()
+		s.WriteString(trimmed)
+	}
 }
 
 func descendsFrom(node string, ancestor string, parents []string) (bool, string) {

--- a/lib.go
+++ b/lib.go
@@ -101,8 +101,21 @@ func prtIdt(s *strings.Builder) {
 	}
 }
 
-func brk(s *strings.Builder) {
+func trimTrailingSpace(s *strings.Builder) {
+	out := s.String()
+	if len(out) == 0 {
+		return
+	}
+	last := out[len(out)-1]
+	if last != ' ' && last != '\t' {
+		return
+	}
+	trimmed := strings.TrimRight(out, " \t")
+	s.Reset()
+	s.WriteString(trimmed)
+}
 
+func brk(s *strings.Builder) {
 	trimTrailingSpace(s)
 	s.WriteByte('\n')
 	// idtStr := ""
@@ -111,15 +124,6 @@ func brk(s *strings.Builder) {
 	// }
 	// s.WriteString(idtStr)
 	line += 1
-}
-
-func trimTrailingSpace(s *strings.Builder) {
-	str := s.String()
-	trimmed := strings.TrimRight(str, " \t")
-	if len(trimmed) != len(str) {
-		s.Reset()
-		s.WriteString(trimmed)
-	}
 }
 
 func descendsFrom(node string, ancestor string, parents []string) (bool, string) {

--- a/testdata/array-out.jq
+++ b/testdata/array-out.jq
@@ -1,5 +1,5 @@
 [
-    "this", 
-    "that", 
+    "this",
+    "that",
     "other"
 ]

--- a/testdata/function-map-out.jq
+++ b/testdata/function-map-out.jq
@@ -1,2 +1,2 @@
-test | 
+test |
 map("test")

--- a/testdata/multi-1-out.jq
+++ b/testdata/multi-1-out.jq
@@ -1,4 +1,4 @@
 [
     one
-] | 
+] |
     (two, three)

--- a/testdata/object-out.jq
+++ b/testdata/object-out.jq
@@ -1,5 +1,5 @@
-{ 
-    one: two, 
-    three: four, 
+{
+    one: two,
+    three: four,
     five: six
 }

--- a/testdata/operator-add-out.jq
+++ b/testdata/operator-add-out.jq
@@ -1,3 +1,3 @@
-this + 
-    that + 
+this +
+    that +
     other

--- a/testdata/operator-alt-out.jq
+++ b/testdata/operator-alt-out.jq
@@ -1,2 +1,2 @@
-this // 
+this //
     that

--- a/testdata/operator-and-out.jq
+++ b/testdata/operator-and-out.jq
@@ -1,3 +1,3 @@
-this and 
-    that and 
+this and
+    that and
     other

--- a/testdata/operator-assign-out.jq
+++ b/testdata/operator-assign-out.jq
@@ -1,2 +1,2 @@
-this = 
+this =
     that

--- a/testdata/operator-comma-out.jq
+++ b/testdata/operator-comma-out.jq
@@ -1,3 +1,3 @@
-one, 
-    two, 
+one,
+    two,
     three

--- a/testdata/operator-div-out.jq
+++ b/testdata/operator-div-out.jq
@@ -1,3 +1,3 @@
-this / 
-    that / 
+this /
+    that /
     other

--- a/testdata/operator-eq-out.jq
+++ b/testdata/operator-eq-out.jq
@@ -1,2 +1,2 @@
-this == 
+this ==
     that

--- a/testdata/operator-ge-out.jq
+++ b/testdata/operator-ge-out.jq
@@ -1,2 +1,2 @@
-this >= 
+this >=
     that

--- a/testdata/operator-gt-out.jq
+++ b/testdata/operator-gt-out.jq
@@ -1,2 +1,2 @@
-this > 
+this >
     that

--- a/testdata/operator-le-out.jq
+++ b/testdata/operator-le-out.jq
@@ -1,2 +1,2 @@
-this <= 
+this <=
     that

--- a/testdata/operator-lt-out.jq
+++ b/testdata/operator-lt-out.jq
@@ -1,2 +1,2 @@
-this < 
+this <
     that

--- a/testdata/operator-mod-out.jq
+++ b/testdata/operator-mod-out.jq
@@ -1,3 +1,3 @@
-this % 
-    that % 
+this %
+    that %
     other

--- a/testdata/operator-modify-out.jq
+++ b/testdata/operator-modify-out.jq
@@ -1,2 +1,2 @@
-this |= 
+this |=
     that

--- a/testdata/operator-mul-out.jq
+++ b/testdata/operator-mul-out.jq
@@ -1,3 +1,3 @@
-this * 
-    that * 
+this *
+    that *
     other

--- a/testdata/operator-ne-out.jq
+++ b/testdata/operator-ne-out.jq
@@ -1,2 +1,2 @@
-this != 
+this !=
     that

--- a/testdata/operator-or-out.jq
+++ b/testdata/operator-or-out.jq
@@ -1,3 +1,3 @@
-this or 
-    that or 
+this or
+    that or
     other

--- a/testdata/operator-pipe-out.jq
+++ b/testdata/operator-pipe-out.jq
@@ -1,3 +1,3 @@
-this | 
-    that | 
+this |
+    that |
     other

--- a/testdata/operator-sub-out.jq
+++ b/testdata/operator-sub-out.jq
@@ -1,3 +1,3 @@
-this - 
-    that - 
+this -
+    that -
     other

--- a/testdata/operator-updateAdd-out.jq
+++ b/testdata/operator-updateAdd-out.jq
@@ -1,2 +1,2 @@
-this += 
+this +=
     that

--- a/testdata/operator-updateAlt-out.jq
+++ b/testdata/operator-updateAlt-out.jq
@@ -1,2 +1,2 @@
-this //= 
+this //=
     that

--- a/testdata/operator-updateDiv-out.jq
+++ b/testdata/operator-updateDiv-out.jq
@@ -1,2 +1,2 @@
-this /= 
+this /=
     that

--- a/testdata/operator-updateMod-out.jq
+++ b/testdata/operator-updateMod-out.jq
@@ -1,2 +1,2 @@
-this %= 
+this %=
     that

--- a/testdata/operator-updateMul-out.jq
+++ b/testdata/operator-updateMul-out.jq
@@ -1,2 +1,2 @@
-this *= 
+this *=
     that

--- a/testdata/operator-updateSub-out.jq
+++ b/testdata/operator-updateSub-out.jq
@@ -1,2 +1,2 @@
-this -= 
+this -=
     that

--- a/testdata/trailing-space-in.jq
+++ b/testdata/trailing-space-in.jq
@@ -1,0 +1,1 @@
+map(select(has("resource")) | .resource.github_repository | to_entries | map(.value | map(.name))) | flatten[]

--- a/testdata/trailing-space-out.jq
+++ b/testdata/trailing-space-out.jq
@@ -1,0 +1,6 @@
+map(select(has("resource")) |
+.resource.github_repository |
+to_entries |
+map(.value |
+map(.name))) |
+    flatten[]


### PR DESCRIPTION
Fixes #11.

**Problem**: jqfmt left trailing spaces before line breaks when formatting full operator pipelines.

**Solution**: Trim trailing spaces/tabs at line breaks and update expected outputs, with a new test covering the reported pipeline case.

**Approach**: Trim at the `brk()` write point so all operator layouts benefit without changing individual formatting rules.